### PR TITLE
Remove CoreFoundation Imports

### DIFF
--- a/Sources/JSONSafeEncoder/JSONError.swift
+++ b/Sources/JSONSafeEncoder/JSONError.swift
@@ -19,7 +19,6 @@ Copyright (c) 2023 Twilio Inc.
 
 
 import Foundation
-import CoreFoundation
 
 enum JSONError: Swift.Error, Equatable {
     case cannotConvertInputDataToUTF8

--- a/Sources/JSONSafeEncoder/JSONSafeEncoder.swift
+++ b/Sources/JSONSafeEncoder/JSONSafeEncoder.swift
@@ -18,7 +18,6 @@ Copyright (c) 2023 Twilio Inc.
 ---------------------------------------------------------------------------------------------**/
 
 import Foundation
-import CoreFoundation
 
 /// A marker protocol used to determine whether a value is a `String`-keyed `Dictionary`
 /// containing `Encodable` values (in which case it should be exempt from key conversion strategies).
@@ -102,16 +101,16 @@ open class JSONSafeEncoder {
     public enum NonConformingFloatEncodingStrategy {
         /// Throw upon encountering non-conforming values. This is the default strategy.
         case `throw`
-        
+
         /// Set the value to null, like Javascript does.
         case `null`
-        
+
         /// Set the value to zero, the safest option for Swift decoding.
         case zero
 
         /// Encode the values using the given representation strings.
         case convertToString(positiveInfinity: String, negativeInfinity: String, nan: String)
-        
+
         /// Default strings, similar to Python
         static var convertToStringDefaults = NonConformingFloatEncodingStrategy.convertToString(
             positiveInfinity: "Infinity",

--- a/Sources/JSONSafeEncoder/JSONValue.swift
+++ b/Sources/JSONSafeEncoder/JSONValue.swift
@@ -18,7 +18,6 @@ Copyright (c) 2023 Twilio Inc.
 ---------------------------------------------------------------------------------------------**/
 
 import Foundation
-import CoreFoundation
 
 internal enum JSONValue: Equatable {
     case string(String)
@@ -39,7 +38,7 @@ extension JSONValue {
             return true
         }
     }
-    
+
     var isContainer: Bool {
         switch self {
         case .array, .object:
@@ -101,4 +100,3 @@ private extension JSONValue {
         }
     }
 }
-


### PR DESCRIPTION
These are non-portable outside of the Darwin set of platforms, and seem unneeded to build the library.

When building on Windows it seemed that these were not needed to build the library, Iso I removed them. This will unblock the main `analytics-swift` library to be portable onto all platforms that Swift supports.